### PR TITLE
Replace deprecated keyword in iam_roles.tf

### DIFF
--- a/iam-roles.tf
+++ b/iam-roles.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "event_trust" {
 # Generate a random string to add it to the name of the Target Group
 resource "random_string" "iam_suffix" {
   length      = 12
-  number      = true
+  numeric      = true
   min_numeric = 12
 }
 


### PR DESCRIPTION
This PR updates the iam_roles.tf file to address deprecation warnings and improve compatibility:

- Replaced deprecated usage of the keyword number with the correct numeric type as per the latest Terraform HCL standards.